### PR TITLE
Update instance and vBond day0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ venv.bak/
 .vscode/
 *.code-workspace
 .idea
+config/config_20_9.yaml
+config/config_20_10.yaml
+docs/NOTES.md

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,5 @@ env.bak/
 venv.bak/
 # IDE project files
 .vscode/
+*.code-workspace
 .idea
-
-

--- a/ansible/day_0/config-certificates.yml
+++ b/ansible/day_0/config-certificates.yml
@@ -1,0 +1,100 @@
+- name: Configure certificates
+  hosts: localhost
+  vars:
+    vmanage_host: "{{ groups.vmanage_hosts | first }}"
+    vmanage_mgmt_interface: "{{ hostvars[vmanage_host].mgmt_interface | default('ansible_host') }}"
+    vmanage_ip: "{{ hostvars[vmanage_host][vmanage_mgmt_interface] | ansible.utils.ipaddr('address') }}"
+    vbond_controller: "{{ groups.vbond_hosts[0] }}"
+  tags:
+    - control
+    - vmanage
+  any_errors_fatal: true
+  gather_facts: no
+  environment: "{{ proxy_env }}"
+  tasks:
+    - name: Add the Enterprise CA
+      cisco.sastre.settings_enterprise_ca:
+        address: "{{ vmanage_ip }}"
+        user: "{{ vmanage_user }}"
+        password: "{{ vmanage_pass }}"
+        root_cert: "{{ lookup('file', '{{ sdwan_ca_cert }}') }}"
+      register: result
+      retries: 10
+      delay: 10
+      until: result is not failed
+
+    - name: Generate CSRs
+      vmanage_device_certificate:
+        host: "{{ vmanage_ip }}"
+        user: "{{ vmanage_user }}"
+        password: "{{ vmanage_pass }}"
+        name: "{{ item }}"
+        transport_ip: "{{ hostvars[item].vpn0_ip | ansible.utils.ipaddr('address')}}"
+        state: csr
+      loop: "{{ groups.sdwan_control }}"
+      register: control_devices
+      retries: 10
+      delay: 10
+      until: control_devices is not failed
+
+    - name: Write out CSR
+      copy:
+        content: "{{ item.deviceCSR }}"
+        dest: "{{ sdwan_cert_dir }}/{{ item.item }}.csr"
+      loop: "{{ control_devices.results }}"
+      delegate_to: localhost
+
+    - name: Sign Controller Cert
+      openssl_certificate:
+        csr_path: "{{ sdwan_cert_dir }}/{{ item }}.csr"
+        path: "{{ sdwan_cert_dir }}/{{ item }}.crt"
+        provider: ownca
+        ownca_path: "{{ sdwan_cert_dir }}/myCA.pem"
+        ownca_privatekey_path: "{{ sdwan_cert_dir }}/myCA.key"
+        ownca_privatekey_passphrase: "{{ sdwan_ca_passphrase }}"
+      loop: "{{ groups.sdwan_control }}"
+      delegate_to: localhost
+
+    - name: Add Certificate to Control Hosts
+      vmanage_device_certificate:
+        host: "{{ vmanage_ip }}"
+        user: "{{ vmanage_user }}"
+        password: "{{ vmanage_pass }}"
+        name: "{{ item }}"
+        transport_ip: "{{ hostvars[item].vpn0_ip | ansible.utils.ipaddr('address')}}"
+        cert: "{{lookup('file', '{{ sdwan_cert_dir }}/{{ item }}.crt')}}"
+      loop: "{{ groups.sdwan_control }}"
+      register: result
+      retries: 10
+      delay: 10
+      until: result is not failed
+
+    - name: Push Certs to Controllers
+      vmanage_device_certificate:
+        host: "{{ vmanage_ip }}"
+        user: "{{ vmanage_user }}"
+        password: "{{ vmanage_pass }}"
+        state: push
+      register: result
+      retries: 10
+      delay: 10
+      until: result is not failed
+
+    - name: Install Serial File
+      vmanage_fileupload:
+        host: "{{ vmanage_ip }}"
+        user: "{{ vmanage_user }}"
+        password: "{{ vmanage_pass }}"
+        file: "{{ sdwan_serial_file }}"
+      delegate_to: localhost
+      register: result
+      retries: 10
+      delay: 10
+      until: result is not failed
+
+    - debug:
+        msg: "vManage IP: {{ vmanage_ip }}"
+
+    - debug:
+        msg: "vManage external IP: {{ sdwan_vmanage }}"
+      when: sdwan_vmanage is defined

--- a/ansible/day_0/config-control-plane.yml
+++ b/ansible/day_0/config-control-plane.yml
@@ -3,3 +3,5 @@
 - import_playbook: check-vmanage.yml
 
 - import_playbook: config-vmanage.yml
+
+- import_playbook: config-certificates.yml

--- a/ansible/day_0/config-vmanage.yml
+++ b/ansible/day_0/config-vmanage.yml
@@ -22,7 +22,7 @@
       register: result
       retries: 30
       delay: 10
-      until: result is not failed 
+      until: result is not failed
 
     - name: Add Control Hosts
       vmanage_device:
@@ -35,86 +35,6 @@
         personality: "{{ hostvars[item].sdwan_personality }}"
         transport_ip: "{{ hostvars[item].vpn0_ip | ansible.utils.ipaddr('address')}}"
       loop: "{{ groups.vbond_hosts + groups.vsmart_hosts }}"
-      register: result
-      retries: 10
-      delay: 10
-      until: result is not failed 
-
-    - name: Add the Enterprise CA
-      cisco.sastre.settings_enterprise_ca:
-        address: "{{ vmanage_ip }}"
-        user: "{{ vmanage_user }}"
-        password: "{{ vmanage_pass }}"
-        root_cert: "{{ lookup('file', '{{ sdwan_ca_cert }}') }}"
-      register: result
-      retries: 10
-      delay: 10
-      until: result is not failed 
-
-    - name: Generate CSRs
-      vmanage_device_certificate:
-        host: "{{ vmanage_ip }}"
-        user: "{{ vmanage_user }}"
-        password: "{{ vmanage_pass }}"
-        name: "{{ item }}"
-        transport_ip: "{{ hostvars[item].vpn0_ip | ansible.utils.ipaddr('address')}}"
-        state: csr
-      loop: "{{ groups.sdwan_control }}"
-      register: control_devices
-      retries: 10
-      delay: 10
-      until: control_devices is not failed 
-
-    - name: Write out CSR
-      copy:
-        content: "{{ item.deviceCSR }}"
-        dest: "{{ sdwan_cert_dir }}/{{ item.item }}.csr"
-      loop: "{{ control_devices.results }}"
-      delegate_to: localhost
-
-    - name: Sign Controller Cert
-      openssl_certificate:
-        csr_path: "{{ sdwan_cert_dir }}/{{ item }}.csr"
-        path: "{{ sdwan_cert_dir }}/{{ item }}.crt"
-        provider: ownca
-        ownca_path: "{{ sdwan_cert_dir }}/myCA.pem"
-        ownca_privatekey_path: "{{ sdwan_cert_dir }}/myCA.key"
-        ownca_privatekey_passphrase: "{{ sdwan_ca_passphrase }}"
-      loop: "{{ groups.sdwan_control }}"
-      delegate_to: localhost
-
-    - name: Add Certificate to Control Hosts
-      vmanage_device_certificate:
-        host: "{{ vmanage_ip }}"
-        user: "{{ vmanage_user }}"
-        password: "{{ vmanage_pass }}"
-        name: "{{ item }}"
-        transport_ip: "{{ hostvars[item].vpn0_ip | ansible.utils.ipaddr('address')}}"
-        cert: "{{lookup('file', '{{ sdwan_cert_dir }}/{{ item }}.crt')}}"
-      loop: "{{ groups.sdwan_control }}"
-      register: result
-      retries: 10
-      delay: 10
-      until: result is not failed 
-
-    - name: Push Certs to Controllers
-      vmanage_device_certificate:
-        host: "{{ vmanage_ip }}"
-        user: "{{ vmanage_user }}"
-        password: "{{ vmanage_pass }}"
-        state: push
-      register: result
-      retries: 10
-      delay: 10
-      until: result is not failed 
-
-    - name: Install Serial File
-      vmanage_fileupload:
-        host: "{{ vmanage_ip }}"
-        user: "{{ vmanage_user }}"
-        password: "{{ vmanage_pass }}"
-        file: "{{ sdwan_serial_file }}"
-      delegate_to: localhost
       register: result
       retries: 10
       delay: 10

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -24,10 +24,10 @@ controllers:
     provider: "aws"
     region: "us-east-1"
   # dns_domain: "acme.com"
-    sw_version: "20.8.1"
+    sw_version: "20.12.1"
     cloud_init_format: v2
   config:
-    organization_name: "Cisco CX Canada"
+    organization_name: "Cisco DevOps"
     site_id: 1
     acl_ingress_ipv4: [ "0.0.0.0/1", "128.0.0.0/1" ]
     acl_ingress_ipv6: [ "::/0" ]
@@ -38,7 +38,7 @@ controllers:
   vmanage:
     infra:
       image_id: "ami-02b3d4da3fc136dab"
-      instance_type: "c5.2xlarge"
+      instance_type: "c5.4xlarge"
     config:
       username: "admin"
       password: "C1sco12345"

--- a/config/templates/sdwan_inventory.j2
+++ b/config/templates/sdwan_inventory.j2
@@ -99,6 +99,10 @@ all:
                           enabled: true
                           ip:
                             address: "{{ controllers.vbond.config.vpn0_interface_ipv4 }}"
+                          tunnel_interface:
+                            encapsulation: ipsec
+                            allow_service:
+                              - all
                       routes:
                         - prefix: 0.0.0.0/0
                           next_hop:

--- a/docs/deploying_controllers_cloud.md
+++ b/docs/deploying_controllers_cloud.md
@@ -25,36 +25,42 @@ All parameters are defined in a single configuration file named **config.yaml** 
 Go to the **config** directory
 
 - copy `config.example.yaml` to `config.yaml`
-- Update required parameters, most likely controllers and wan-edge ami image identifiers as well as wan-edge UUID (from vManage device list) .
+- Update required parameters, most likely your ssh_public_key, controllers and wan-edge ami image identifiers as well as wan-edge UUIDs.
 
 ## Define environnement variables
 
 Go to the **bin** folder.
 
-Update your AWS profile name in file **minimum_env.sh** (if this is not "default").
+Update your AWS profile name in file **minimal_env.sh** (if this is not "default").
 
 Set environnement variables (make sure to use source ....)
 
-- `source minimum_env.sh`
+```shell
+source minimal_env.sh
+```
 
 ## Config Builder
 
 With **bin** as your current folder, build all ansible parameter files:
 
-- `./config_build.sh`
+```shell
+./config_build.sh
+```
 
-This will render parameter files for ansible playbooks based on jinja templates:
+This will render parameter files for ansible playbooks based on **config/config.yaml** and **jinja templates**:
 
-- Ansible day*-1 vars: 'day-1_local.j2' -> '../ansible/day*-1/group_vars/all/local.yml'
-- Ansible day_0 vars: 'day0_local.j2' -> '../ansible/day_0/group_vars/all/local.yml'
-- Ansible day_1 vars: 'day1_local.j2' -> '../ansible/day_1/group_vars/all/local.yml'
-- Ansible SDWAN inventory: 'sdwan_inventory.j2' -> '../ansible/inventory/sdwan_inventory.yml'
+- Ansible day-1 vars: 'config/templates/day-1_local.j2' -> '../ansible/day_-1/group_vars/all/local.yml'
+- Ansible day_0 vars: 'config/templates/day0_local.j2' -> '../ansible/day_0/group_vars/all/local.yml'
+- Ansible day_1 vars: 'config/templates/day1_local.j2' -> '../ansible/day_1/group_vars/all/local.yml'
+- Ansible SDWAN inventory: 'config/templates/sdwan_inventory.j2' -> '../ansible/inventory/sdwan_inventory.yml'
 
 ## Create CA (Day -1)
 
 With **bin** as your current folder, run the script to create certificates:
 
-- `./install_ca.sh`
+```shell
+./install_ca.sh
+```
 
 This will create a local CA in **ansible/myCA**.
 
@@ -62,7 +68,9 @@ This will create a local CA in **ansible/myCA**.
 
 With **bin** as your current folder, deploy and configure Control Plane:
 
-- `./install_cp.sh`
+```shell
+./install_cp.sh
+```
 
 This will execute ansible playbook: **/ansible/day_0/build-control-plane.yml**
 
@@ -75,16 +83,28 @@ Which imports:
     - /ansible/day_0/check-vmanage.yml
     - /ansible/day_0/config-vmanage.yml
 
-Or execute individual playbooks:
+You can also execute individual playbooks if you want to check every step of the process:
 
-- `./play.sh /ansible/day_0/deploy-control-plane.yml`
-- `./play.sh /ansible/day_0/check-reqs.yml`
-- `./play.sh /ansible/day_0/check-vmanage.yml`
-- `./play.sh /ansible/day_0/config-vmanage.yml`
-- `./play.sh /ansible/day_0/config-certificates.yml`
+```shell
+./play.sh /ansible/day_0/deploy-control-plane.yml
+./play.sh /ansible/day_0/check-reqs.yml
+./play.sh /ansible/day_0/check-vmanage.yml
+./play.sh /ansible/day_0/config-vmanage.yml
+./play.sh /ansible/day_0/config-certificates.yml
+```
+
+Notes:
+
+- deploy-control-plane.yml: generate day0 configurations and instantiate all controllers.
+- check-reqs.yml: check org-name is defined and serial file exists.
+- check-vmanage.yml: check vManage is able to respond to REST API calls. Can take a while (~60 retries or 15 sec each).
+- config-vmanage.yml: configure vManage settings and add vBond and vSmart controllers to vManage.
+- config-certificates.yml: add certificates for all controllers.
 
 ## Deleting Controllers
 
 With **bin** as your current folder:
 
-- `./delete_cp.sh`
+```shell
+./delete_cp.sh
+```

--- a/docs/deploying_controllers_cloud.md
+++ b/docs/deploying_controllers_cloud.md
@@ -1,6 +1,5 @@
 # Deploying Controllers on AWS
 
-
 ## Cloning repo
 
 Clone the sdwan-devops repo using the cloud branch (most up to date):
@@ -11,23 +10,22 @@ Make sure you use `--recursive` to also clone folders sdwan-edge and terraform-s
 
 All operations are run out of the sdwan-devops directory: `cd sdwan-devops`
 
-
 ## License file
 
 Generate a licence file corresponding to your org-name that will contain your device UUIDs:
+
 - https://software.cisco.com/software/csws/ws/platform/home?locale=en_US#pnp-devices
 
 Download and copy into `ansible/licences`
 
-
-## Configure parameters 
+## Configure parameters
 
 All parameters are defined in a single configuration file named **config.yaml** under folder **config**.
 
-Go to the **config** directory 
+Go to the **config** directory
+
 - copy `config.example.yaml` to `config.yaml`
 - Update required parameters, most likely controllers and wan-edge ami image identifiers as well as wan-edge UUID (from vManage device list) .
-
 
 ## Define environnement variables
 
@@ -36,55 +34,57 @@ Go to the **bin** folder.
 Update your AWS profile name in file **minimum_env.sh** (if this is not "default").
 
 Set environnement variables (make sure to use source ....)
-  - `source minimum_env.sh`
 
+- `source minimum_env.sh`
 
 ## Config Builder
 
-With **bin** as your current folder, build all ansible parameter files: 
+With **bin** as your current folder, build all ansible parameter files:
+
 - `./config_build.sh`
 
 This will render parameter files for ansible playbooks based on jinja templates:
-- Ansible day_-1 vars: 'day-1_local.j2' -> '../ansible/day_-1/group_vars/all/local.yml'
+
+- Ansible day*-1 vars: 'day-1_local.j2' -> '../ansible/day*-1/group_vars/all/local.yml'
 - Ansible day_0 vars: 'day0_local.j2' -> '../ansible/day_0/group_vars/all/local.yml'
 - Ansible day_1 vars: 'day1_local.j2' -> '../ansible/day_1/group_vars/all/local.yml'
 - Ansible SDWAN inventory: 'sdwan_inventory.j2' -> '../ansible/inventory/sdwan_inventory.yml'
 
-
 ## Create CA (Day -1)
 
 With **bin** as your current folder, run the script to create certificates:
+
 - `./install_ca.sh`
 
 This will create a local CA in **ansible/myCA**.
 
-
 ## Deploy Controllers (day0)
 
 With **bin** as your current folder, deploy and configure Control Plane:
+
 - `./install_cp.sh`
 
 This will execute ansible playbook: **/ansible/day_0/build-control-plane.yml**
 
 Which imports:
+
 - /ansible/day_0/deploy-control-plane.yml
 - /ansible/day_0/config-control-plane.yml
-   - which in turns, imports:
-      - /ansible/day_0/check-reqs.yml
-      - /ansible/day_0/check-vmanage.yml
-      - /ansible/day_0/config-vmanage.yml
+  - which in turns, imports:
+    - /ansible/day_0/check-reqs.yml
+    - /ansible/day_0/check-vmanage.yml
+    - /ansible/day_0/config-vmanage.yml
 
 Or execute individual playbooks:
+
 - `./play.sh /ansible/day_0/deploy-control-plane.yml`
 - `./play.sh /ansible/day_0/check-reqs.yml`
 - `./play.sh /ansible/day_0/check-vmanage.yml`
 - `./play.sh /ansible/day_0/config-vmanage.yml`
-
+- `./play.sh /ansible/day_0/config-certificates.yml`
 
 ## Deleting Controllers
 
 With **bin** as your current folder:
+
 - `./delete_cp.sh`
-
-
-


### PR DESCRIPTION
A couple of updates:
- Change vManage EC2 instance type from "c5.2xlarge"` to: "c5.4xlarge" (required with 20.12), otherwise out of memory
- Add tunnel interface to vBond to be able to add vBond to vManage. Seems to be new from 20.10
- Create separate playbook for certificates