### PR TITLE
Improving documentation starting from circleci.

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -2,7 +2,9 @@
 
 ## Variables
 
-See the list of possible environment variables in the follwoing table. They can be set in the project settings, or part of an organization-wide context. Without setting the **required** variables, the pipeline will fail.
+See the list of possible environment variables in the following table. They can be set in the project settings, or part of an organization-wide context. Without setting the **required** variables, the pipeline will fail.
+
+Note that the required variables are also set in the [minimal_env.sh](../bin/minimal_env.sh) script.
 
 > **NOTE** The default values usually come from Terraform defaults defined in the `terraform-sdwan` submodule, not as variables defined in the Ansible code. That means that the variables themselves may not be defined at all, even if the table shows they have a default value.
 

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -4,8 +4,6 @@
 
 See the list of possible environment variables in the following table. They can be set in the project settings, or part of an organization-wide context. Without setting the **required** variables, the pipeline will fail.
 
-Note that the required variables are also set in the [minimal_env.sh](../bin/minimal_env.sh) script.
-
 > **NOTE** The default values usually come from Terraform defaults defined in the `terraform-sdwan` submodule, not as variables defined in the Ansible code. That means that the variables themselves may not be defined at all, even if the table shows they have a default value.
 
 | Name                    | Importance  | Default value  | Recommended value      | Notes |

--- a/bin/config_build.sh
+++ b/bin/config_build.sh
@@ -4,7 +4,8 @@ CONFTEST_VERSION=${CONFTEST_VERSION:-v0.47.0}
 
 set -o pipefail
 
-# Uncomment the line below if you want to enforce the OPA rules in `config/policy/config.rego`
+# Uncomment the line below if you want to enforce the OPA rules in `config/policy/config.rego` that check the AWS instance types for given SD-WAN versions.
+# See config/policy/README for further explanation.
 #set -e
 
 echo "[i] Running conftest on config.yaml ..."

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,6 +1,6 @@
 ---
 global_config:
-  # Different cloud have diufferent restrictions on the characters allowed in
+  # Different cloud have different restrictions on the characters allowed in
   # the tags. AWS is the most permisive, GCP is the most restrictive, Azure is
   # somewhere in the middle. If you use all lowercase letters and numbers, you
   # should be fine.

--- a/config/policy/README.md
+++ b/config/policy/README.md
@@ -1,3 +1,3 @@
 The [config.rego](./config.rego) file in this directory implements [Open Policy Agent](https://www.openpolicyagent.org/docs/latest/policy-language/) uses the contents of [data.yaml](./data.yaml) to check that the correct AWS VM instance types are being used with respect to the given SD-WAN contoller versions.
 
-If this policy is not enforce, then the controllers and vManage might not start up correctly.
+If this policy is not enforced, then the controllers and vManage might not start up correctly.

--- a/config/policy/README.md
+++ b/config/policy/README.md
@@ -1,0 +1,3 @@
+The [config.rego](./config.rego) file in this directory implements [Open Policy Agent](https://www.openpolicyagent.org/docs/latest/policy-language/) uses the contents of [data.yaml](./data.yaml) to check that the correct AWS VM instance types are being used with respect to the given SD-WAN contoller versions.
+
+If this policy is not enforce, then the controllers and vManage might not start up correctly.

--- a/sdwan_config_builder/README.md
+++ b/sdwan_config_builder/README.md
@@ -41,7 +41,7 @@ SDWAN Config Builder Tool Version 0.7
 ## Running
 
 The metadata file defines the location of the source configuration file, jinja2 templates, and where the output files 
-should be saved. By default sdwan_config_build look for a 'metadata.yaml' file in the same directory where it is run. 
+should be saved. By default sdwan_config_build looks for a 'metadata.yaml' file in the directory where it is run. 
 The CONFIG_BUILDER_METADATA environment variable can be used to specify a custom location for the metadata file.
 
 ```


### PR DESCRIPTION
As discussed elsewhere, I am working out from the .circleci towards updated documentation for build. 

One of the key questions to start with is how to set the required variables. There is a `bin/minimal_env.sh` script that could be used uniformly. The CircleCI documentation suggests that the variables need to be set in the CircleCI env though.

Which is the best approach? Ideally, we would have a single place to set variables, but that might not be desirable for reasons to do with how CircleCI works that I am not aware of.

Also, we have, in minimal_env:

```
export GOOGLE_CREDENTIALS=$(cat key.json | tr -s '\n' ' ')
```

Where the `key.json` is explicitly .gitignore'd. Ideally, we would have an example `key.json`, or at least some explanation of where to get that file from.